### PR TITLE
fix: persists tool call id across stream chunks

### DIFF
--- a/agents/models_chatcmpl_stream_handler.go
+++ b/agents/models_chatcmpl_stream_handler.go
@@ -253,7 +253,9 @@ func (chatCmplStreamHandler) HandleStream(
 
 			tc.Arguments += tcFunction.Arguments
 			tc.Name += tcFunction.Name
-			tc.CallID = tcDelta.ID
+			if len(tcDelta.ID) > 0 {
+				tc.CallID = tcDelta.ID
+			}
 		}
 	}
 


### PR DESCRIPTION
tool_call id will be only returned in first chunk of the chat completion stream. hence if rewrite the call id for every chunk, the state's function call variable will only get empty call id eventually