### PR TITLE
examples(model_providers): add custom LLM provider examples (agent/global/provider) + LiteLLM, with docs

### DIFF
--- a/examples/model_providers/README.md
+++ b/examples/model_providers/README.md
@@ -1,0 +1,52 @@
+# Custom LLM providers (Go Examples)
+
+This directory mirrors the official Python examples for using non-OpenAI providers with the OpenAI Agents SDK, adapted for Go.
+
+## Examples
+
+- custom_example_provider: Provide a custom `ModelProvider` and use it via `Runner`.
+- custom_example_agent: Set a custom client per agent using `WithModelInstance(...)`.
+- custom_example_global: Set a global default OpenAI client and default API (`chat_completions`).
+- custom_example_litellm: Use LiteLLM (Docker) as an OpenAI-compatible proxy. Includes MultiProvider with prefix routing and a global-default example.
+
+## Prerequisites
+
+For the first three examples, set the following environment variables (or edit the code):
+
+```bash
+export EXAMPLE_BASE_URL="http://your-provider-host"
+export EXAMPLE_API_KEY="your-provider-api-key"
+export EXAMPLE_MODEL_NAME="model-name"
+```
+
+For LiteLLM, start a Docker container (requires `OPENAI_API_KEY` for upstream providers):
+
+```bash
+docker run \
+  -v $(pwd)/litellm_config.yaml:/app/config.yaml \
+  -e OPENAI_API_KEY="$OPENAI_API_KEY" \
+  -p 4000:4000 \
+  ghcr.io/berriai/litellm:main-stable \
+  --config /app/config.yaml \
+  --detailed_debug
+```
+
+Then run:
+
+```bash
+go run ./examples/model_providers/custom_example_provider
+go run ./examples/model_providers/custom_example_agent
+go run ./examples/model_providers/custom_example_global
+go run ./examples/model_providers/custom_example_litellm
+```
+
+## Notes on Parity with Python
+
+The Go examples match the Python variants conceptually:
+
+- Per-agent client: `custom_example_agent.go` ↔ `custom_example_agent.py`
+- Global default client: `custom_example_global.go` ↔ `custom_example_global.py`
+- Runner-level provider: `custom_example_provider.go` ↔ `custom_example_provider.py`
+- LiteLLM routing: `custom_example_litellm/main.go` shows direct provider, MultiProvider prefix routing (`litellm/...`), and global default — corresponding to Python's `litellm_auto.py` and `litellm_provider.py` patterns.
+
+

--- a/examples/model_providers/custom_example_litellm/README.md
+++ b/examples/model_providers/custom_example_litellm/README.md
@@ -1,0 +1,257 @@
+# LiteLLM Docker Integration Example
+
+This example demonstrates how to integrate the OpenAI Agents Go SDK with LiteLLM running locally in Docker. LiteLLM acts as a unified proxy that provides OpenAI-compatible APIs for multiple LLM providers including OpenAI, Anthropic, Google, and local models.
+
+## 🏗️ Architecture
+
+```
+┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
+│  Go Application │────│  LiteLLM Docker │────│  LLM Providers  │
+│  (Agents SDK)   │    │  (Port 4000)    │    │  (OpenAI, etc.) │
+└─────────────────┘    └─────────────────┘    └─────────────────┘
+```
+
+## 🚀 Quick Start
+
+### Prerequisites
+
+1. **Docker** installed and running
+2. **OpenAI API Key** (set as environment variable)
+3. **Go 1.21+** for running the example
+
+### Step 1: Start LiteLLM Docker Container
+
+```bash
+# Set your OpenAI API key
+export OPENAI_API_KEY="sk-your-openai-api-key-here"
+
+# Start LiteLLM with the provided config
+docker run \
+  -v $(pwd)/litellm_config.yaml:/app/config.yaml \
+  -e OPENAI_API_KEY="$OPENAI_API_KEY" \
+  -p 4000:4000 \
+  ghcr.io/berriai/litellm:main-stable \
+  --config /app/config.yaml \
+  --detailed_debug
+```
+
+### Step 2: Verify LiteLLM is Running
+
+```bash
+# Test the endpoint
+curl --location 'http://localhost:4000/chat/completions' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "model": "openai-gpt-4o",
+    "messages": [{"role": "user", "content": "Hello from LiteLLM!"}],
+    "max_tokens": 50
+  }'
+```
+
+### Step 3: Run the Go Example
+
+```bash
+# From the example directory
+go run main.go
+```
+
+## 📋 Example Features
+
+The example demonstrates **three different integration patterns**:
+
+### 1. Direct LiteLLM Provider
+```go
+// Create a dedicated LiteLLM provider
+litellmProvider := NewLiteLLMProvider("", "")
+
+// Use it directly with an agent
+result, err := (agents.Runner{
+    Config: agents.RunConfig{
+        ModelProvider: litellmProvider,
+        Model: param.NewOpt(agents.NewAgentModelName("openai-gpt-4o")),
+    },
+}).Run(context.Background(), agent, "Your prompt here")
+```
+
+### 2. MultiProvider with Prefix Routing
+```go
+// Setup multiple providers with prefixes
+providerMap := agents.NewMultiProviderMap()
+providerMap.AddProvider("litellm", NewLiteLLMProvider("", ""))
+
+multiProvider := agents.NewMultiProvider(agents.NewMultiProviderParams{
+    ProviderMap: providerMap,
+})
+
+// Use with prefix-based model names
+agent.WithModel("litellm/openai-gpt-4o")
+```
+
+### 3. Global Default Provider
+```go
+// Set LiteLLM as the global default
+litellmClient := agents.NewOpenaiClient(
+    param.NewOpt("http://localhost:4000"),
+    param.NewOpt("dummy-key"),
+)
+agents.SetDefaultOpenaiClient(litellmClient, false)
+
+// Now all agents use LiteLLM by default
+agent.WithModel("openai-gpt-4o") // No prefix needed
+```
+
+## 🔧 Configuration
+
+### LiteLLM Config (`litellm_config.yaml`)
+
+The configuration supports multiple providers:
+
+```yaml
+model_list:
+  # OpenAI Models
+  - model_name: openai-gpt-4o
+    litellm_params:
+      model: openai/gpt-4o-mini
+      api_key: os.environ/OPENAI_API_KEY
+
+  # Anthropic Models
+  - model_name: claude-3-sonnet
+    litellm_params:
+      model: anthropic/claude-3-5-sonnet-20240620
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+  # Local Ollama Models
+  - model_name: ollama-llama3
+    litellm_params:
+      model: ollama/llama3
+      api_base: http://localhost:11434
+```
+
+### Environment Variables
+
+Set these environment variables for different providers:
+
+```bash
+# Required for OpenAI models
+export OPENAI_API_KEY="sk-..."
+
+# Optional for Anthropic models
+export ANTHROPIC_API_KEY="sk-ant-..."
+
+# Optional for Google models
+export GOOGLE_API_KEY="..."
+```
+
+## 🎯 Advanced Features
+
+### Model Fallbacks
+
+LiteLLM supports automatic fallbacks if a model is unavailable:
+
+```yaml
+general_settings:
+  fallbacks:
+    - openai-gpt-4o
+    - openai-gpt-4o-mini
+```
+
+### Custom Headers and Settings
+
+```go
+// Add custom headers for specific providers
+modelSettings := modelsettings.ModelSettings{
+    ExtraHeaders: map[string]string{
+        "X-LiteLLM-Provider": "anthropic",
+        "X-Custom-Header":    "value",
+    },
+}
+
+agent.WithModelSettings(modelSettings)
+```
+
+### Health Check
+
+The example includes a connection check:
+
+```go
+func checkLiteLLMConnection() bool {
+    // Attempts a simple request to verify LiteLLM is accessible
+    // Returns true if LiteLLM is running and responsive
+}
+```
+
+## 🐛 Troubleshooting
+
+### Common Issues
+
+1. **Connection Refused**
+   ```
+   Error: connection refused on port 4000
+   ```
+   **Solution**: Ensure Docker container is running and port 4000 is not blocked.
+
+2. **API Key Errors**
+   ```
+   Error: 401 Unauthorized
+   ```
+   **Solution**: Check that your API keys are properly set in environment variables.
+
+3. **Model Not Found**
+   ```
+   Error: model "xyz" not found
+   ```
+   **Solution**: Verify the model name matches what's defined in `litellm_config.yaml`.
+
+### Debug Mode
+
+Enable verbose logging in LiteLLM:
+
+```yaml
+general_settings:
+  set_verbose: true
+```
+
+Or check Docker logs:
+
+```bash
+docker logs <container-id>
+```
+
+## 🌐 Multi-Provider Setup
+
+### Adding More Providers
+
+To add support for additional providers, update `litellm_config.yaml`:
+
+```yaml
+model_list:
+  # Hugging Face
+  - model_name: hf-codellama
+    litellm_params:
+      model: huggingface/codellama/CodeLlama-7b-Instruct-hf
+      api_key: os.environ/HUGGINGFACE_API_KEY
+
+  # Cohere
+  - model_name: cohere-command
+    litellm_params:
+      model: cohere/command-r-plus
+      api_key: os.environ/COHERE_API_KEY
+```
+
+## 🎉 Benefits
+
+1. **Provider Flexibility**: Switch between providers without code changes
+2. **Cost Optimization**: Route to cheaper models when appropriate
+3. **High Availability**: Automatic fallbacks if a provider is down
+4. **Local Development**: Test with local models via Ollama
+5. **Unified Interface**: Single API for all providers
+
+## 📚 Further Reading
+
+- [LiteLLM Documentation](https://docs.litellm.ai/)
+- [OpenAI Agents Go SDK](https://github.com/nlpodyssey/openai-agents-go)
+- [Supported LiteLLM Providers](https://docs.litellm.ai/docs/providers)
+
+---
+
+This example showcases the power and flexibility of the OpenAI Agents Go SDK's provider system, enabling seamless integration with any OpenAI-compatible service!

--- a/examples/model_providers/custom_example_litellm/litellm_config.yaml
+++ b/examples/model_providers/custom_example_litellm/litellm_config.yaml
@@ -1,0 +1,39 @@
+model_list:
+  # OpenAI Models
+  - model_name: openai-gpt-4o
+    litellm_params:
+      model: openai/gpt-4o-mini
+      api_key: os.environ/OPENAI_API_KEY
+
+  - model_name: openai-gpt-4o-mini
+    litellm_params:
+      model: openai/gpt-4o-mini
+      api_key: os.environ/OPENAI_API_KEY
+
+  # Anthropic Models (if you have the key)
+  - model_name: claude-3-sonnet
+    litellm_params:
+      model: anthropic/claude-3-5-sonnet-20240620
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+  # Google Models (if you have the key)
+  - model_name: gemini-pro
+    litellm_params:
+      model: gemini/gemini-pro
+      api_key: os.environ/GOOGLE_API_KEY
+
+  # Ollama Local Models (if running locally)
+  - model_name: ollama-llama3
+    litellm_params:
+      model: ollama/llama3
+      api_base: http://localhost:11434
+
+# General settings
+general_settings:
+  # Log level for debugging
+  set_verbose: true
+  
+  # Enable model fallbacks
+  fallbacks:
+    - openai-gpt-4o
+    - openai-gpt-4o-mini

--- a/examples/model_providers/custom_example_litellm/main.go
+++ b/examples/model_providers/custom_example_litellm/main.go
@@ -1,0 +1,250 @@
+// Copyright 2025 The NLP Odyssey Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/nlpodyssey/openai-agents-go/agents"
+	"github.com/nlpodyssey/openai-agents-go/tracing"
+	"github.com/openai/openai-go/v2"
+	"github.com/openai/openai-go/v2/packages/param"
+	"github.com/openai/openai-go/v2/shared/constant"
+)
+
+/*
+This example demonstrates how to use LiteLLM running locally in Docker as a model provider.
+
+Prerequisites:
+1. Docker with LiteLLM running on port 4000 (see README.md for setup)
+2. OpenAI API key set in environment or docker container
+
+The example shows three different approaches:
+1. Direct LiteLLM provider with local Docker endpoint
+2. Using MultiProvider with prefix routing (litellm/model-name)
+3. Setting LiteLLM as the global default provider
+
+Run this after starting your Docker container:
+docker run -v $(pwd)/litellm_config.yaml:/app/config.yaml -e OPENAI_API_KEY="sk-..." -p 4000:4000 ghcr.io/berriai/litellm:main-stable --config /app/config.yaml --detailed_debug
+*/
+
+// LiteLLMProvider implements ModelProvider for local LiteLLM Docker instance
+type LiteLLMProvider struct {
+	baseURL string
+	apiKey  string
+	client  *agents.OpenaiClient
+}
+
+// NewLiteLLMProvider creates a provider that connects to local LiteLLM Docker instance
+func NewLiteLLMProvider(baseURL, apiKey string) *LiteLLMProvider {
+	if baseURL == "" {
+		baseURL = "http://localhost:4000" // Default Docker port
+	}
+	if apiKey == "" {
+		apiKey = "dummy-key" // LiteLLM proxy doesn't always require the actual key
+	}
+
+	client := agents.NewOpenaiClient(
+		param.NewOpt(baseURL),
+		param.NewOpt(apiKey),
+	)
+
+	return &LiteLLMProvider{
+		baseURL: baseURL,
+		apiKey:  apiKey,
+		client:  &client,
+	}
+}
+
+// GetModel returns a model that connects to LiteLLM
+func (p *LiteLLMProvider) GetModel(modelName string) (agents.Model, error) {
+	if modelName == "" {
+		modelName = "openai-gpt-4o" // Default model from our config
+	}
+
+	log.Printf("Creating LiteLLM model: %s via %s", modelName, p.baseURL)
+	return agents.NewOpenAIChatCompletionsModel(modelName, *p.client), nil
+}
+
+// Weather tool for demonstration
+type GetWeatherArgs struct {
+	City string `json:"city" description:"The city to get weather for"`
+}
+
+func GetWeather(ctx context.Context, args GetWeatherArgs) (string, error) {
+	fmt.Printf("🌤️  [debug] Getting weather for %s\n", args.City)
+	return fmt.Sprintf("The weather in %s is sunny with a temperature of 22°C.", args.City), nil
+}
+
+var GetWeatherTool = agents.NewFunctionTool("get_weather", "Get current weather for a city", GetWeather)
+
+func init() {
+	// Disable tracing for this example
+	tracing.SetTracingDisabled(true)
+}
+
+func main() {
+	fmt.Println("🚀 Starting LiteLLM Docker Integration Example")
+	fmt.Println(strings.Repeat("=", 50))
+
+	// Verify LiteLLM is running
+	if !checkLiteLLMConnection() {
+		fmt.Println("❌ LiteLLM Docker container not accessible on port 4000")
+		fmt.Println("Please start LiteLLM Docker first:")
+		fmt.Println("docker run -v $(pwd)/litellm_config.yaml:/app/config.yaml -e OPENAI_API_KEY=\"your-key\" -p 4000:4000 ghcr.io/berriai/litellm:main-stable --config /app/config.yaml")
+		os.Exit(1)
+	}
+
+	fmt.Println("✅ LiteLLM Docker container is running")
+
+	// Example 1: Direct LiteLLM Provider
+	fmt.Println("\n📝 Example 1: Direct LiteLLM Provider")
+	fmt.Println(strings.Repeat("-", 40))
+	runDirectLiteLLMExample()
+
+	// Example 2: MultiProvider with Prefix Routing
+	fmt.Println("\n📝 Example 2: MultiProvider with Prefix Routing")
+	fmt.Println(strings.Repeat("-", 40))
+	runMultiProviderExample()
+
+	// Example 3: Global Default Provider
+	fmt.Println("\n📝 Example 3: Global Default Provider")
+	fmt.Println(strings.Repeat("-", 40))
+	runGlobalDefaultExample()
+
+	fmt.Println("\n🎉 All examples completed successfully!")
+}
+
+// Example 1: Using LiteLLM provider directly
+func runDirectLiteLLMExample() {
+	litellmProvider := NewLiteLLMProvider("", "")
+
+	agent := agents.New("Weather Assistant").
+		WithInstructions("You are a helpful weather assistant. Always use the get_weather tool to get current weather data.").
+		WithTools(GetWeatherTool)
+
+	result, err := (agents.Runner{
+		Config: agents.RunConfig{
+			ModelProvider: litellmProvider,
+			Model:         param.NewOpt(agents.NewAgentModelName("openai-gpt-4o")),
+		},
+	}).Run(context.Background(), agent, "What's the weather like in Tokyo?")
+
+	if err != nil {
+		log.Printf("❌ Error in direct provider example: %v", err)
+		return
+	}
+
+	fmt.Printf("🤖 Response: %s\n", result.FinalOutput)
+}
+
+// Example 2: Using MultiProvider with prefix routing
+func runMultiProviderExample() {
+	// Setup providers
+	providerMap := agents.NewMultiProviderMap()
+	providerMap.AddProvider("litellm", NewLiteLLMProvider("", ""))
+
+	multiProvider := agents.NewMultiProvider(agents.NewMultiProviderParams{
+		ProviderMap: providerMap,
+	})
+
+	agent := agents.New("Travel Assistant").
+		WithInstructions("You are a travel assistant. You respond in a friendly, enthusiastic way about travel destinations.").
+		WithTools(GetWeatherTool)
+
+	// Note the "litellm/" prefix in the model name
+	result, err := (agents.Runner{
+		Config: agents.RunConfig{
+			ModelProvider: multiProvider,
+			Model:         param.NewOpt(agents.NewAgentModelName("litellm/openai-gpt-4o")),
+		},
+	}).Run(context.Background(), agent, "I'm planning a trip to Paris. What should I know about the weather?")
+
+	if err != nil {
+		log.Printf("❌ Error in multi-provider example: %v", err)
+		return
+	}
+
+	fmt.Printf("🤖 Response: %s\n", result.FinalOutput)
+}
+
+// Example 3: Setting LiteLLM as global default
+func runGlobalDefaultExample() {
+	// Set up LiteLLM as the global default client
+	litellmClient := agents.NewOpenaiClient(
+		param.NewOpt("http://localhost:4000"),
+		param.NewOpt("dummy-key"),
+	)
+
+	// Store current defaults to restore later
+	originalClient := agents.GetDefaultOpenaiClient()
+	originalUseResponses := agents.GetUseResponsesByDefault()
+
+	// Set LiteLLM as default
+	agents.SetDefaultOpenaiClient(litellmClient, false)
+	agents.SetDefaultOpenaiAPI(agents.OpenaiAPITypeChatCompletions)
+
+	defer func() {
+		// Restore original settings
+		if originalClient != nil {
+			agents.SetDefaultOpenaiClient(*originalClient, false)
+		} else {
+			agents.ClearOpenaiSettings()
+		}
+		agents.SetUseResponsesByDefault(originalUseResponses)
+	}()
+
+	agent := agents.New("Poet Assistant").
+		WithInstructions("You are a creative poet. Always end your responses with a short haiku about the topic.").
+		WithModel("openai-gpt-4o"). // No prefix needed when using global default
+		WithTools(GetWeatherTool)
+
+	result, err := agents.Run(context.Background(), agent, "Tell me about the weather in San Francisco and write a poem about it")
+
+	if err != nil {
+		log.Printf("❌ Error in global default example: %v", err)
+		return
+	}
+
+	fmt.Printf("🤖 Response: %s\n", result.FinalOutput)
+}
+
+// Helper function to check if LiteLLM is accessible
+func checkLiteLLMConnection() bool {
+	client := agents.NewOpenaiClient(
+		param.NewOpt("http://localhost:4000"),
+		param.NewOpt("dummy-key"),
+	)
+
+	// Simple test request
+	_, err := client.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
+		Model: "openai-gpt-4o",
+		Messages: []openai.ChatCompletionMessageParamUnion{{
+			OfUser: &openai.ChatCompletionUserMessageParam{
+				Content: openai.ChatCompletionUserMessageParamContentUnion{
+					OfString: param.NewOpt("test"),
+				},
+				Role: constant.ValueOf[constant.User](),
+			},
+		}},
+		MaxTokens: param.NewOpt(int64(1)),
+	})
+
+	return err == nil
+}

--- a/examples/model_providers/custom_example_litellm/test.sh
+++ b/examples/model_providers/custom_example_litellm/test.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# Test script for LiteLLM Docker Integration Example
+set -e
+
+echo "🧪 LiteLLM Docker Integration Test Script"
+echo "=========================================="
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Check if Docker is running
+if ! docker info > /dev/null 2>&1; then
+    echo -e "${RED}❌ Docker is not running. Please start Docker first.${NC}"
+    exit 1
+fi
+
+# Check if OpenAI API key is set
+if [ -z "$OPENAI_API_KEY" ]; then
+    echo -e "${YELLOW}⚠️  OPENAI_API_KEY not set. Setting a dummy key for testing...${NC}"
+    export OPENAI_API_KEY="sk-dummy-key-for-testing"
+fi
+
+echo -e "${GREEN}✅ Docker is running${NC}"
+echo -e "${GREEN}✅ API key is set${NC}"
+
+# Check if LiteLLM container is already running
+if docker ps | grep -q "litellm"; then
+    echo -e "${GREEN}✅ LiteLLM container is already running${NC}"
+else
+    echo -e "${YELLOW}📦 Starting LiteLLM Docker container...${NC}"
+    
+    # Start LiteLLM container
+    docker run -d \
+        --name litellm-test \
+        -v $(pwd)/litellm_config.yaml:/app/config.yaml \
+        -e OPENAI_API_KEY="$OPENAI_API_KEY" \
+        -p 4000:4000 \
+        ghcr.io/berriai/litellm:main-stable \
+        --config /app/config.yaml \
+        --detailed_debug
+    
+    echo -e "${GREEN}✅ LiteLLM container started${NC}"
+    
+    # Wait for container to be ready
+    echo -e "${YELLOW}⏳ Waiting for LiteLLM to be ready...${NC}"
+    sleep 10
+fi
+
+# Test LiteLLM endpoint
+echo -e "${YELLOW}🔍 Testing LiteLLM endpoint...${NC}"
+response=$(curl -s -o /dev/null -w "%{http_code}" \
+    --location 'http://localhost:4000/chat/completions' \
+    --header 'Content-Type: application/json' \
+    --data '{
+        "model": "openai-gpt-4o",
+        "messages": [{"role": "user", "content": "test"}],
+        "max_tokens": 1
+    }')
+
+if [ "$response" = "200" ]; then
+    echo -e "${GREEN}✅ LiteLLM endpoint is responsive${NC}"
+else
+    echo -e "${RED}❌ LiteLLM endpoint returned HTTP $response${NC}"
+    echo -e "${YELLOW}📋 Container logs:${NC}"
+    docker logs litellm-test --tail 20
+    exit 1
+fi
+
+# Run the Go example
+echo -e "${YELLOW}🚀 Running Go example...${NC}"
+if go run main.go; then
+    echo -e "${GREEN}✅ Go example completed successfully!${NC}"
+else
+    echo -e "${RED}❌ Go example failed${NC}"
+    exit 1
+fi
+
+# Cleanup function
+cleanup() {
+    echo -e "${YELLOW}🧹 Cleaning up...${NC}"
+    docker stop litellm-test > /dev/null 2>&1 || true
+    docker rm litellm-test > /dev/null 2>&1 || true
+    echo -e "${GREEN}✅ Cleanup complete${NC}"
+}
+
+# Ask if user wants to keep container running
+echo ""
+read -p "Keep LiteLLM container running? (y/N): " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    cleanup
+else
+    echo -e "${GREEN}🐳 LiteLLM container will keep running on port 4000${NC}"
+    echo -e "${YELLOW}To stop it later, run: docker stop litellm-test && docker rm litellm-test${NC}"
+fi
+
+echo -e "${GREEN}🎉 Test completed!${NC}" 


### PR DESCRIPTION
Adds Go examples for using custom model providers, matching the official Python examples.
What’s included

New examples under examples/model_providers:
- custom_example_provider: Runner-level custom ModelProvider
- custom_example_agent: per-agent custom client via WithModelInstance(...)
- custom_example_global: global default OpenAI client + default API
- custom_example_litellm: LiteLLM integration (direct provider, MultiProvider prefix routing, global default)

Documentation:
- examples/model_providers/README.md (parity with Python docs)
- examples/model_providers/custom_example_litellm/README.md + litellm_config.yaml

Scope and impact
- Examples and docs only; no production code changes
- No breaking changes

Solves issue 
https://github.com/nlpodyssey/openai-agents-go/issues/4