### PR TITLE
memory(psql): add PostgreSQL-backed session store with tests

### DIFF
--- a/memory/psql_session.go
+++ b/memory/psql_session.go
@@ -1,0 +1,382 @@
+// Copyright 2025 The NLP Odyssey Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memory
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"sync"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// PgRowsInterface abstracts the rows operations for easier mocking
+type PgRowsInterface interface {
+	Next() bool
+	Scan(dest ...any) error
+	Err() error
+	Close()
+}
+
+// PgRowInterface abstracts the row operations for easier mocking
+type PgRowInterface interface {
+	Scan(dest ...any) error
+}
+
+// PgConnInterface abstracts the database operations needed by PgSession.
+// This allows for easy mocking in tests.
+type PgConnInterface interface {
+	Query(ctx context.Context, sql string, args ...any) (PgRowsInterface, error)
+	QueryRow(ctx context.Context, sql string, args ...any) PgRowInterface
+	Exec(ctx context.Context, sql string, args ...any) (any, error)
+	Close(ctx context.Context) error
+}
+
+// PgRowsWrapper wraps pgx.Rows to implement PgRowsInterface
+type PgRowsWrapper struct {
+	rows pgx.Rows
+}
+
+func (w *PgRowsWrapper) Next() bool {
+	return w.rows.Next()
+}
+
+func (w *PgRowsWrapper) Scan(dest ...any) error {
+	return w.rows.Scan(dest...)
+}
+
+func (w *PgRowsWrapper) Err() error {
+	return w.rows.Err()
+}
+
+func (w *PgRowsWrapper) Close() {
+	w.rows.Close()
+}
+
+// PgRowWrapper wraps pgx.Row to implement PgRowInterface
+type PgRowWrapper struct {
+	row pgx.Row
+}
+
+func (w *PgRowWrapper) Scan(dest ...any) error {
+	return w.row.Scan(dest...)
+}
+
+// PgConnWrapper wraps a real pgx.Conn to implement PgConnInterface
+type PgConnWrapper struct {
+	conn *pgx.Conn
+}
+
+func (w *PgConnWrapper) Query(ctx context.Context, sql string, args ...any) (PgRowsInterface, error) {
+	rows, err := w.conn.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, err
+	}
+	return &PgRowsWrapper{rows: rows}, nil
+}
+
+func (w *PgConnWrapper) QueryRow(ctx context.Context, sql string, args ...any) PgRowInterface {
+	row := w.conn.QueryRow(ctx, sql, args...)
+	return &PgRowWrapper{row: row}
+}
+
+func (w *PgConnWrapper) Exec(ctx context.Context, sql string, args ...any) (any, error) {
+	return w.conn.Exec(ctx, sql, args...)
+}
+
+func (w *PgConnWrapper) Close(ctx context.Context) error {
+	return w.conn.Close(ctx)
+}
+
+// PgSession is a PostgreSQL-based implementation of Session storage.
+//
+// This implementation stores conversation history in a PostgreSQL database.
+// Requires a valid PostgreSQL connection string.
+type PgSession struct {
+	sessionID     string
+	connString    string
+	sessionTable  string
+	messagesTable string
+	conn          PgConnInterface
+	mu            sync.Mutex
+}
+
+type PgSessionParams struct {
+	// Unique identifier for the conversation session
+	SessionID string
+
+	// PostgreSQL connection string.
+	// Example: "postgres://user:password@localhost:5432/database"
+	ConnectionString string
+
+	// Optional name of the table to store session metadata.
+	// Defaults to "agent_sessions".
+	SessionTable string
+
+	// Optional name of the table to store message data.
+	// Defaults to "agent_messages".
+	MessagesTable string
+
+	// Optional connection interface for dependency injection (mainly for testing)
+	Conn PgConnInterface
+}
+
+// NewPgSession initializes the PostgreSQL session.
+func NewPgSession(ctx context.Context, params PgSessionParams) (_ *PgSession, err error) {
+	s := &PgSession{
+		sessionID:     params.SessionID,
+		connString:    params.ConnectionString,
+		sessionTable:  cmp.Or(params.SessionTable, "agent_sessions"),
+		messagesTable: cmp.Or(params.MessagesTable, "agent_messages"),
+		conn:          params.Conn,
+	}
+
+	defer func() {
+		if err != nil {
+			if s.conn != nil {
+				if e := s.conn.Close(ctx); e != nil {
+					err = errors.Join(err, e)
+				}
+			}
+		}
+	}()
+
+	// If no connection provided, create a real one
+	if s.conn == nil {
+		if params.ConnectionString == "" {
+			return nil, fmt.Errorf("connection string is required")
+		}
+
+		realConn, err := pgx.Connect(ctx, s.connString)
+		if err != nil {
+			return nil, fmt.Errorf("failed to connect to PostgreSQL: %w", err)
+		}
+		s.conn = &PgConnWrapper{conn: realConn}
+	}
+
+	err = s.initDB(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (s *PgSession) SessionID(context.Context) string {
+	return s.sessionID
+}
+
+func (s *PgSession) GetItems(ctx context.Context, limit int) (_ []TResponseInputItem, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var rows PgRowsInterface
+	if limit <= 0 {
+		// Fetch all items in chronological order
+		rows, err = s.conn.Query(ctx, fmt.Sprintf(`
+			SELECT message_data FROM %s
+			WHERE session_id = $1
+			ORDER BY created_at ASC
+		`, s.messagesTable), s.sessionID)
+	} else {
+		// Fetch the latest N items in chronological order
+		rows, err = s.conn.Query(ctx, fmt.Sprintf(`
+			SELECT message_data FROM %s
+			WHERE session_id = $1
+			ORDER BY created_at DESC
+			LIMIT $2
+		`, s.messagesTable), s.sessionID, limit)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("error querying session items: %w", err)
+	}
+	defer rows.Close()
+
+	var items []TResponseInputItem
+	for rows.Next() {
+		var messageData string
+		if err = rows.Scan(&messageData); err != nil {
+			return nil, fmt.Errorf("pgx rows scan error: %w", err)
+		}
+
+		item, err := unmarshalMessageData(messageData)
+		if err != nil {
+			continue // Skip invalid JSON entries
+		}
+		items = append(items, item)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("pgx rows scan error: %w", err)
+	}
+
+	// Reverse to get chronological order when using DESC
+	if limit > 0 {
+		slices.Reverse(items)
+	}
+
+	return items, nil
+}
+
+func (s *PgSession) AddItems(ctx context.Context, items []TResponseInputItem) error {
+	if len(items) == 0 {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Ensure session exists
+	_, err := s.conn.Exec(
+		ctx,
+		fmt.Sprintf(`INSERT INTO %s (session_id) VALUES ($1) ON CONFLICT (session_id) DO NOTHING`, s.sessionTable),
+		s.sessionID,
+	)
+	if err != nil {
+		return fmt.Errorf("error ensuring session exists: %w", err)
+	}
+
+	// Add items
+	for _, item := range items {
+		jsonItem, err := item.MarshalJSON()
+		if err != nil {
+			return fmt.Errorf("error JSON marshaling item: %w", err)
+		}
+		_, err = s.conn.Exec(
+			ctx,
+			fmt.Sprintf(`INSERT INTO %s (session_id, message_data) VALUES ($1, $2)`, s.messagesTable),
+			s.sessionID, string(jsonItem),
+		)
+		if err != nil {
+			return fmt.Errorf("error inserting item in messages table: %w", err)
+		}
+	}
+
+	// Update session timestamp
+	_, err = s.conn.Exec(
+		ctx,
+		fmt.Sprintf(`UPDATE %s SET updated_at = NOW() WHERE session_id = $1`, s.sessionTable),
+		s.sessionID,
+	)
+	if err != nil {
+		return fmt.Errorf("error updating session timestamp: %w", err)
+	}
+
+	return nil
+}
+
+func (s *PgSession) PopItem(ctx context.Context) (*TResponseInputItem, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var messageData string
+	err := s.conn.QueryRow(
+		ctx,
+		fmt.Sprintf(`
+			DELETE FROM %s
+			WHERE id = (
+				SELECT id FROM %s
+				WHERE session_id = $1
+				ORDER BY created_at DESC
+				LIMIT 1
+			)
+			RETURNING message_data
+		`, s.messagesTable, s.messagesTable),
+		s.sessionID,
+	).Scan(&messageData)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("error popping item: %w", err)
+	}
+
+	item, err := unmarshalMessageData(messageData)
+	if err != nil {
+		return nil, nil // Return nil for corrupted JSON entries (already deleted)
+	}
+
+	return &item, nil
+}
+
+func (s *PgSession) ClearSession(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	_, err := s.conn.Exec(
+		ctx,
+		fmt.Sprintf(`DELETE FROM %s WHERE session_id = $1`, s.messagesTable),
+		s.sessionID,
+	)
+	if err != nil {
+		return fmt.Errorf("error clearing messages: %w", err)
+	}
+
+	_, err = s.conn.Exec(
+		ctx,
+		fmt.Sprintf(`DELETE FROM %s WHERE session_id = $1`, s.sessionTable),
+		s.sessionID,
+	)
+	if err != nil {
+		return fmt.Errorf("error clearing session: %w", err)
+	}
+
+	return nil
+}
+
+// Initialize the database schema.
+func (s *PgSession) initDB(ctx context.Context) error {
+	_, err := s.conn.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
+			session_id TEXT PRIMARY KEY,
+			created_at TIMESTAMP DEFAULT NOW(),
+			updated_at TIMESTAMP DEFAULT NOW()
+		)
+	`, s.sessionTable))
+	if err != nil {
+		return fmt.Errorf("error creating session table: %w", err)
+	}
+
+	_, err = s.conn.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
+			id SERIAL PRIMARY KEY,
+			session_id TEXT NOT NULL,
+			message_data TEXT NOT NULL,
+			created_at TIMESTAMP DEFAULT NOW(),
+			FOREIGN KEY (session_id) REFERENCES %s (session_id) ON DELETE CASCADE
+		)
+	`, s.messagesTable, s.sessionTable))
+	if err != nil {
+		return fmt.Errorf("error creating messages table: %w", err)
+	}
+
+	_, err = s.conn.Exec(ctx, fmt.Sprintf(
+		`CREATE INDEX IF NOT EXISTS idx_%s_session_id ON %s (session_id, created_at)`,
+		s.messagesTable, s.messagesTable))
+	if err != nil {
+		return fmt.Errorf("error creating index: %w", err)
+	}
+
+	return nil
+}
+
+// Close the database connection.
+func (s *PgSession) Close(ctx context.Context) error {
+	if s.conn != nil {
+		return s.conn.Close(ctx)
+	}
+	return nil
+}

--- a/memory/psql_session_test.go
+++ b/memory/psql_session_test.go
@@ -1,0 +1,562 @@
+// Copyright 2025 The NLP Odyssey Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memory
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/openai/openai-go/v2/packages/param"
+	"github.com/openai/openai-go/v2/responses"
+	"github.com/openai/openai-go/v2/shared/constant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// MockPgConn is a mock implementation of PgConnInterface for testing
+type MockPgConn struct {
+	mock.Mock
+}
+
+func (m *MockPgConn) Query(ctx context.Context, sql string, args ...any) (PgRowsInterface, error) {
+	arguments := []any{ctx, sql}
+	arguments = append(arguments, args...)
+	ret := m.Called(arguments...)
+	return ret.Get(0).(PgRowsInterface), ret.Error(1)
+}
+
+func (m *MockPgConn) QueryRow(ctx context.Context, sql string, args ...any) PgRowInterface {
+	arguments := []any{ctx, sql}
+	arguments = append(arguments, args...)
+	ret := m.Called(arguments...)
+	return ret.Get(0).(PgRowInterface)
+}
+
+func (m *MockPgConn) Exec(ctx context.Context, sql string, args ...any) (any, error) {
+	arguments := []any{ctx, sql}
+	arguments = append(arguments, args...)
+	ret := m.Called(arguments...)
+	return ret.Get(0), ret.Error(1)
+}
+
+func (m *MockPgConn) Close(ctx context.Context) error {
+	ret := m.Called(ctx)
+	return ret.Error(0)
+}
+
+// MockPgRows is a mock implementation of PgRowsInterface for testing
+type MockPgRows struct {
+	data []string
+	pos  int
+}
+
+func NewMockPgRows(data []string) *MockPgRows {
+	return &MockPgRows{data: data, pos: -1}
+}
+
+func (m *MockPgRows) Next() bool {
+	m.pos++
+	return m.pos < len(m.data)
+}
+
+func (m *MockPgRows) Scan(dest ...any) error {
+	if m.pos >= len(m.data) {
+		return fmt.Errorf("no more rows")
+	}
+	if len(dest) > 0 {
+		if strPtr, ok := dest[0].(*string); ok {
+			*strPtr = m.data[m.pos]
+		}
+	}
+	return nil
+}
+
+func (m *MockPgRows) Err() error {
+	return nil
+}
+
+func (m *MockPgRows) Close() {}
+
+// MockPgRow is a mock implementation of PgRowInterface for testing
+type MockPgRow struct {
+	data  string
+	empty bool
+}
+
+func NewMockPgRow(data string, empty bool) *MockPgRow {
+	return &MockPgRow{data: data, empty: empty}
+}
+
+func (m *MockPgRow) Scan(dest ...any) error {
+	if m.empty {
+		return pgx.ErrNoRows
+	}
+	if len(dest) > 0 {
+		if strPtr, ok := dest[0].(*string); ok {
+			*strPtr = m.data
+		}
+	}
+	return nil
+}
+
+// Helper function to create test session with mock connection
+func createMockPgSession(t *testing.T, sessionID string, mockConn *MockPgConn) *PgSession {
+	session, err := NewPgSession(context.Background(), PgSessionParams{
+		SessionID:     sessionID,
+		SessionTable:  "test_sessions",
+		MessagesTable: "test_messages",
+		Conn:          mockConn,
+	})
+	require.NoError(t, err)
+	return session
+}
+
+// Helper function to create test message items
+func createTestItems() []TResponseInputItem {
+	return []TResponseInputItem{
+		{OfMessage: &responses.EasyInputMessageParam{
+			Content: responses.EasyInputMessageContentUnionParam{OfString: param.NewOpt("Hello")},
+			Role:    responses.EasyInputMessageRoleUser,
+			Type:    responses.EasyInputMessageTypeMessage,
+		}},
+		{OfMessage: &responses.EasyInputMessageParam{
+			Content: responses.EasyInputMessageContentUnionParam{OfString: param.NewOpt("Hi there!")},
+			Role:    responses.EasyInputMessageRoleAssistant,
+			Type:    responses.EasyInputMessageTypeMessage,
+		}},
+		{OfMessage: &responses.EasyInputMessageParam{
+			Content: responses.EasyInputMessageContentUnionParam{OfString: param.NewOpt("How are you?")},
+			Role:    responses.EasyInputMessageRoleUser,
+			Type:    responses.EasyInputMessageTypeMessage,
+		}},
+	}
+}
+
+func TestPgSession_NewPgSession(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("missing connection string and no conn provided", func(t *testing.T) {
+		_, err := NewPgSession(ctx, PgSessionParams{
+			SessionID: "test",
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "connection string is required")
+	})
+
+	t.Run("successful creation with mock connection", func(t *testing.T) {
+		mockConn := &MockPgConn{}
+
+		// Mock the initDB calls
+		mockConn.On("Exec", mock.Anything, mock.MatchedBy(func(sql string) bool {
+			return fmt.Sprintf(sql, "test_sessions") != ""
+		})).Return(nil, nil).Once()
+
+		mockConn.On("Exec", mock.Anything, mock.MatchedBy(func(sql string) bool {
+			return fmt.Sprintf(sql, "test_messages", "test_sessions") != ""
+		})).Return(nil, nil).Once()
+
+		mockConn.On("Exec", mock.Anything, mock.MatchedBy(func(sql string) bool {
+			return fmt.Sprintf(sql, "test_messages", "test_messages") != ""
+		})).Return(nil, nil).Once()
+
+		session, err := NewPgSession(ctx, PgSessionParams{
+			SessionID:     "test",
+			SessionTable:  "test_sessions",
+			MessagesTable: "test_messages",
+			Conn:          mockConn,
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, "test", session.SessionID(ctx))
+		assert.Equal(t, "test_sessions", session.sessionTable)
+		assert.Equal(t, "test_messages", session.messagesTable)
+
+		mockConn.AssertExpectations(t)
+	})
+}
+
+func TestPgSession_GetItems(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("no limit - empty session", func(t *testing.T) {
+		mockConn := &MockPgConn{}
+
+		// Mock initDB calls
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string")).Return(nil, nil).Times(3)
+
+		// Mock empty query result
+		mockRows := NewMockPgRows([]string{})
+		mockConn.On("Query", mock.Anything, mock.AnythingOfType("string"), "test").Return(mockRows, nil)
+
+		session := createMockPgSession(t, "test", mockConn)
+
+		items, err := session.GetItems(ctx, 0)
+		require.NoError(t, err)
+		assert.Empty(t, items)
+
+		mockConn.AssertExpectations(t)
+	})
+
+	t.Run("no limit - with items", func(t *testing.T) {
+		mockConn := &MockPgConn{}
+
+		// Mock initDB calls
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string")).Return(nil, nil).Times(3)
+
+		// Create test data
+		testItems := createTestItems()
+		var jsonData []string
+		for _, item := range testItems {
+			jsonBytes, _ := item.MarshalJSON()
+			jsonData = append(jsonData, string(jsonBytes))
+		}
+
+		mockRows := NewMockPgRows(jsonData)
+		mockConn.On("Query", mock.Anything, mock.AnythingOfType("string"), "test").Return(mockRows, nil)
+
+		session := createMockPgSession(t, "test", mockConn)
+
+		items, err := session.GetItems(ctx, 0)
+		require.NoError(t, err)
+		assert.Len(t, items, 3)
+		assert.Equal(t, testItems, items)
+
+		mockConn.AssertExpectations(t)
+	})
+
+	t.Run("with limit", func(t *testing.T) {
+		mockConn := &MockPgConn{}
+
+		// Mock initDB calls
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string")).Return(nil, nil).Times(3)
+
+		// Create test data - should return last 2 items in reverse order due to DESC then reverse
+		testItems := createTestItems()
+		var jsonData []string
+		// Mock returns items in DESC order (last 2 items)
+		for i := len(testItems) - 1; i >= len(testItems)-2; i-- {
+			jsonBytes, _ := testItems[i].MarshalJSON()
+			jsonData = append(jsonData, string(jsonBytes))
+		}
+
+		mockRows := NewMockPgRows(jsonData)
+		mockConn.On("Query", mock.Anything, mock.AnythingOfType("string"), "test", 2).Return(mockRows, nil)
+
+		session := createMockPgSession(t, "test", mockConn)
+
+		items, err := session.GetItems(ctx, 2)
+		require.NoError(t, err)
+		assert.Len(t, items, 2)
+		// Should be last 2 items in chronological order
+		assert.Equal(t, testItems[1:], items)
+
+		mockConn.AssertExpectations(t)
+	})
+}
+
+func TestPgSession_AddItems(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("empty items list", func(t *testing.T) {
+		mockConn := &MockPgConn{}
+
+		// Mock initDB calls
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string")).Return(nil, nil).Times(3)
+
+		session := createMockPgSession(t, "test", mockConn)
+
+		err := session.AddItems(ctx, []TResponseInputItem{})
+		assert.NoError(t, err)
+
+		mockConn.AssertExpectations(t)
+	})
+
+	t.Run("single item", func(t *testing.T) {
+		mockConn := &MockPgConn{}
+
+		// Mock initDB calls
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string")).Return(nil, nil).Times(3)
+
+		// Mock session creation
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string"), "test").Return(nil, nil).Once()
+
+		// Mock item insertion
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string"), "test", mock.AnythingOfType("string")).Return(nil, nil).Once()
+
+		// Mock timestamp update
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string"), "test").Return(nil, nil).Once()
+
+		session := createMockPgSession(t, "test", mockConn)
+
+		testItems := createTestItems()
+		err := session.AddItems(ctx, testItems[:1])
+		require.NoError(t, err)
+
+		mockConn.AssertExpectations(t)
+	})
+
+	t.Run("multiple items", func(t *testing.T) {
+		mockConn := &MockPgConn{}
+
+		// Mock initDB calls
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string")).Return(nil, nil).Times(3)
+
+		// Mock session creation
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string"), "test").Return(nil, nil).Once()
+
+		// Mock item insertions (3 items)
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string"), "test", mock.AnythingOfType("string")).Return(nil, nil).Times(3)
+
+		// Mock timestamp update
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string"), "test").Return(nil, nil).Once()
+
+		session := createMockPgSession(t, "test", mockConn)
+
+		testItems := createTestItems()
+		err := session.AddItems(ctx, testItems)
+		require.NoError(t, err)
+
+		mockConn.AssertExpectations(t)
+	})
+}
+
+func TestPgSession_PopItem(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("from empty session", func(t *testing.T) {
+		mockConn := &MockPgConn{}
+
+		// Mock initDB calls
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string")).Return(nil, nil).Times(3)
+
+		// Mock empty result (no rows)
+		mockRow := NewMockPgRow("", true)
+		mockConn.On("QueryRow", mock.Anything, mock.AnythingOfType("string"), "test").Return(mockRow)
+
+		session := createMockPgSession(t, "test", mockConn)
+
+		item, err := session.PopItem(ctx)
+		require.NoError(t, err)
+		assert.Nil(t, item)
+
+		mockConn.AssertExpectations(t)
+	})
+
+	t.Run("from session with items", func(t *testing.T) {
+		mockConn := &MockPgConn{}
+
+		// Mock initDB calls
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string")).Return(nil, nil).Times(3)
+
+		// Create test data
+		testItems := createTestItems()
+		lastItem := testItems[len(testItems)-1]
+		jsonBytes, _ := lastItem.MarshalJSON()
+
+		mockRow := NewMockPgRow(string(jsonBytes), false)
+		mockConn.On("QueryRow", mock.Anything, mock.AnythingOfType("string"), "test").Return(mockRow)
+
+		session := createMockPgSession(t, "test", mockConn)
+
+		item, err := session.PopItem(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, item)
+		assert.Equal(t, lastItem, *item)
+
+		mockConn.AssertExpectations(t)
+	})
+}
+
+func TestPgSession_ClearSession(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("clear session", func(t *testing.T) {
+		mockConn := &MockPgConn{}
+
+		// Mock initDB calls
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string")).Return(nil, nil).Times(3)
+
+		// Mock clear operations
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string"), "test").Return(nil, nil).Times(2)
+
+		session := createMockPgSession(t, "test", mockConn)
+
+		err := session.ClearSession(ctx)
+		require.NoError(t, err)
+
+		mockConn.AssertExpectations(t)
+	})
+}
+
+func TestPgSession_OutputMessage(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("output message handling", func(t *testing.T) {
+		mockConn := &MockPgConn{}
+
+		// Mock initDB calls
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string")).Return(nil, nil).Times(3)
+
+		// Mock session creation
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string"), "test").Return(nil, nil).Once()
+
+		// Mock item insertion
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string"), "test", mock.AnythingOfType("string")).Return(nil, nil).Once()
+
+		// Mock timestamp update
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string"), "test").Return(nil, nil).Once()
+
+		session := createMockPgSession(t, "test", mockConn)
+
+		// Test with output message (similar to SQLite test for unmarshalMessageData fix)
+		outputItem := TResponseInputItem{
+			OfOutputMessage: &responses.ResponseOutputMessageParam{
+				ID: "msg_123",
+				Content: []responses.ResponseOutputMessageContentUnionParam{
+					{OfOutputText: &responses.ResponseOutputTextParam{
+						Text: "Output message test",
+						Type: constant.ValueOf[constant.OutputText](),
+					}},
+				},
+				Status: responses.ResponseOutputMessageStatusCompleted,
+				Role:   constant.ValueOf[constant.Assistant](),
+				Type:   constant.ValueOf[constant.Message](),
+			},
+		}
+
+		err := session.AddItems(ctx, []TResponseInputItem{outputItem})
+		require.NoError(t, err)
+
+		mockConn.AssertExpectations(t)
+	})
+}
+
+func TestPgSession_Concurrency(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("concurrent operations", func(t *testing.T) {
+		mockConn := &MockPgConn{}
+
+		// Mock initDB calls
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string")).Return(nil, nil).Times(3)
+
+		// For concurrent operations, we expect multiple session creation and item insertion calls
+		const numGoroutines = 5
+		const itemsPerGoroutine = 10
+
+		// Mock session creation calls (may be called multiple times due to concurrency)
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string"), "test").Return(nil, nil).Maybe()
+
+		// Mock item insertions (50 total items)
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string"), "test", mock.AnythingOfType("string")).Return(nil, nil).Times(numGoroutines * itemsPerGoroutine)
+
+		// Mock timestamp updates (may be called multiple times)
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string"), "test").Return(nil, nil).Maybe()
+
+		session := createMockPgSession(t, "test", mockConn)
+
+		// Test concurrent AddItems calls
+		done := make(chan error, numGoroutines)
+
+		for i := 0; i < numGoroutines; i++ {
+			go func(id int) {
+				var items []TResponseInputItem
+				for j := 0; j < itemsPerGoroutine; j++ {
+					items = append(items, TResponseInputItem{
+						OfMessage: &responses.EasyInputMessageParam{
+							Content: responses.EasyInputMessageContentUnionParam{
+								OfString: param.NewOpt(fmt.Sprintf("Goroutine %d, Item %d", id, j)),
+							},
+							Role: responses.EasyInputMessageRoleUser,
+							Type: responses.EasyInputMessageTypeMessage,
+						},
+					})
+				}
+				done <- session.AddItems(ctx, items)
+			}(i)
+		}
+
+		// Wait for all goroutines to complete
+		for i := 0; i < numGoroutines; i++ {
+			assert.NoError(t, <-done)
+		}
+
+		// Note: We can't assert exact call counts due to concurrency and the way mocks work
+		// The important thing is that no errors occurred and all operations completed
+	})
+}
+
+func TestPgSession_ErrorHandling(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("query error", func(t *testing.T) {
+		mockConn := &MockPgConn{}
+
+		// Mock initDB calls
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string")).Return(nil, nil).Times(3)
+
+		// Mock query error
+		mockConn.On("Query", mock.Anything, mock.AnythingOfType("string"), "test").Return((*MockPgRows)(nil), fmt.Errorf("database error"))
+
+		session := createMockPgSession(t, "test", mockConn)
+
+		_, err := session.GetItems(ctx, 0)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "error querying session items")
+
+		mockConn.AssertExpectations(t)
+	})
+
+	t.Run("exec error in AddItems", func(t *testing.T) {
+		mockConn := &MockPgConn{}
+
+		// Mock initDB calls
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string")).Return(nil, nil).Times(3)
+
+		// Mock session creation error
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string"), "test").Return(nil, fmt.Errorf("database error"))
+
+		session := createMockPgSession(t, "test", mockConn)
+
+		testItems := createTestItems()
+		err := session.AddItems(ctx, testItems[:1])
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "error ensuring session exists")
+
+		mockConn.AssertExpectations(t)
+	})
+
+	t.Run("invalid JSON in unmarshalMessageData", func(t *testing.T) {
+		mockConn := &MockPgConn{}
+
+		// Mock initDB calls
+		mockConn.On("Exec", mock.Anything, mock.AnythingOfType("string")).Return(nil, nil).Times(3)
+
+		// Mock query with invalid JSON
+		mockRows := NewMockPgRows([]string{"invalid json"})
+		mockConn.On("Query", mock.Anything, mock.AnythingOfType("string"), "test").Return(mockRows, nil)
+
+		session := createMockPgSession(t, "test", mockConn)
+
+		items, err := session.GetItems(ctx, 0)
+		require.NoError(t, err)
+		assert.Empty(t, items) // Invalid JSON should be skipped
+
+		mockConn.AssertExpectations(t)
+	})
+}


### PR DESCRIPTION
Adds a PostgreSQL-backed Session implementation to memory:
- memory/psql_session.go: connection wrappers, CRUD for session/messages, concurrency-safe ops, schema init, and cleanup
- memory/psql_session_test.go: comprehensive unit tests using mocked pgx interfaces (rows/row/exec), covering happy paths, limits/ordering, concurrency, and error handling

Why?
- Provide a production-grade, SQL-backed session store alternative to in-memory/SQLite
- Aligns with enterprise deployments where Postgres is standard

Highlights:
- Dependency-injection friendly via PgConnInterface for easy mocking
- Safe concurrency with internal locking
- Robust error handling; invalid JSON entries are skipped gracefully
- Proper schema creation and indexing on first use

Testing
- Unit tests included; no external DB required
- For integration tests, provide a ConnectionString and run go test ./memory -run PgSession -v

Scope
- Adds new files only; no breaking changes