### PR TITLE
feat: add tool call arguments in AgentHooks.OnToolStart

### DIFF
--- a/agents/agent_hooks_test.go
+++ b/agents/agent_hooks_test.go
@@ -54,7 +54,7 @@ func (h *AgentHooksForTests) OnHandoff(context.Context, *agents.Agent, *agents.A
 	return nil
 }
 
-func (h *AgentHooksForTests) OnToolStart(context.Context, *agents.Agent, agents.Tool) error {
+func (h *AgentHooksForTests) OnToolStart(context.Context, *agents.Agent, agents.Tool, any) error {
 	h.Events["OnToolStart"] += 1
 	return nil
 }

--- a/agents/computer_action_test.go
+++ b/agents/computer_action_test.go
@@ -200,7 +200,7 @@ type LoggingAgentHooks struct {
 func (h *LoggingAgentHooks) OnStart(context.Context, *Agent) error           { return nil }
 func (h *LoggingAgentHooks) OnEnd(context.Context, *Agent, any) error        { return nil }
 func (h *LoggingAgentHooks) OnHandoff(context.Context, *Agent, *Agent) error { return nil }
-func (h *LoggingAgentHooks) OnToolStart(_ context.Context, agent *Agent, tool Tool) error {
+func (h *LoggingAgentHooks) OnToolStart(_ context.Context, agent *Agent, tool Tool, arguments any) error {
 	h.Started = append(h.Started, []any{agent, tool})
 	return nil
 }

--- a/agents/lifecycle.go
+++ b/agents/lifecycle.go
@@ -84,7 +84,7 @@ type AgentHooks interface {
 	OnHandoff(ctx context.Context, agent, source *Agent) error
 
 	// OnToolStart is called concurrently with tool invocation.
-	OnToolStart(ctx context.Context, agent *Agent, tool Tool) error
+	OnToolStart(ctx context.Context, agent *Agent, tool Tool, arguments any) error
 
 	// OnToolEnd is called after a tool is invoked.
 	OnToolEnd(ctx context.Context, agent *Agent, tool Tool, result any) error

--- a/agents/run_impl.go
+++ b/agents/run_impl.go
@@ -719,7 +719,7 @@ func (runImpl) ExecuteFunctionToolCalls(
 					wg.Add(1)
 					go func() {
 						defer wg.Done()
-						err := agent.Hooks.OnToolStart(ctx, agent, funcTool)
+						err := agent.Hooks.OnToolStart(ctx, agent, funcTool, toolCall.Arguments)
 						if err != nil {
 							cancel()
 							hooksErrors[1] = fmt.Errorf("AgentHooks.OnToolStart failed: %w", err)
@@ -1342,7 +1342,7 @@ func (ca computerAction) Execute(
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			err := agent.Hooks.OnToolStart(childCtx, agent, action.ComputerTool)
+			err := agent.Hooks.OnToolStart(childCtx, agent, action.ComputerTool, nil)
 			if err != nil {
 				cancel()
 				hooksErrors[1] = fmt.Errorf("AgentHooks.OnToolStart failed: %w", err)
@@ -1485,7 +1485,7 @@ func (localShellAction) Execute(
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			err := agent.Hooks.OnToolStart(childCtx, agent, call.LocalShellTool)
+			err := agent.Hooks.OnToolStart(childCtx, agent, call.LocalShellTool, nil)
 			if err != nil {
 				cancel()
 				hooksErrors[1] = fmt.Errorf("AgentHooks.OnToolStart failed: %w", err)

--- a/examples/basic/agent_lifecycle_example/agent_lifecycle_example.go
+++ b/examples/basic/agent_lifecycle_example/agent_lifecycle_example.go
@@ -60,7 +60,7 @@ func (h *CustomAgentHooks) OnHandoff(_ context.Context, agent, source *agents.Ag
 	return nil
 }
 
-func (h *CustomAgentHooks) OnToolStart(_ context.Context, agent *agents.Agent, tool agents.Tool) error {
+func (h *CustomAgentHooks) OnToolStart(_ context.Context, agent *agents.Agent, tool agents.Tool, arguments any) error {
 	h.eventCounter += 1
 	fmt.Printf(
 		"### (%s) %d: Agent %s started tool %s\n",


### PR DESCRIPTION
When the tool call is a function call, to analyze the accuracy of tool call, add the tool call arguments in OnToolStart hook is helpful