### PR TITLE
OpenAI reasoning items not including encrypted content

### DIFF
--- a/openaitypes/openaitypes.go
+++ b/openaitypes/openaitypes.go
@@ -222,11 +222,16 @@ func ResponseInputItemUnionParamFromResponseReasoningItem(
 func ResponseReasoningItemToParam(
 	input responses.ResponseReasoningItem,
 ) responses.ResponseReasoningItemParam {
+	var encryptedContent param.Opt[string]
+	if input.EncryptedContent != "" {
+		encryptedContent = param.NewOpt(input.EncryptedContent)
+	}
 	return responses.ResponseReasoningItemParam{
-		ID:      input.ID,
-		Summary: ResponseReasoningItemSummarySliceToParams(input.Summary),
-		Status:  input.Status,
-		Type:    constant.ValueOf[constant.Reasoning](),
+		ID:               input.ID,
+		Summary:          ResponseReasoningItemSummarySliceToParams(input.Summary),
+		Status:           input.Status,
+		EncryptedContent: encryptedContent,
+		Type:             constant.ValueOf[constant.Reasoning](),
 	}
 }
 


### PR DESCRIPTION
Reasoning items for OpenAI do not include `encrypted_content`, making the requests fail when `store: false` is used