### PR TITLE
Panics on model StreamResponse not returning error to sequence

### DIFF
--- a/agents/run.go
+++ b/agents/run.go
@@ -747,6 +747,11 @@ func (r Runner) startStreaming(
 	var currentSpan tracing.Span
 
 	defer func() {
+		// Recover from panics to ensure the queue is properly closed
+		if r := recover(); r != nil {
+			err = errors.Join(err, fmt.Errorf("startStreaming panicked: %v", r))
+		}
+
 		if err != nil {
 			var agentsErr *AgentsError
 			if errors.As(err, &agentsErr) {


### PR DESCRIPTION
When doing

```go
stream, err := runner.RunStreamedSeq(ctx, initialAgent, "Hello world")
if err != nil {
   return fmt.Errorf("run stream: %w", err)
}

for event := range stream.Seq {
   // Handling code
}

if stream.Err != nil {
   // Handle error
}
```

If the `StreamResponse` method from the model implementation panics, no error is returned to the stream, causing it to hang forever.

---

PS: It would be nice if a new release is made with all recent changes