### PR TITLE
Fix session persistence for web/file search tool calls

### DIFF
--- a/agents/items_run_item.go
+++ b/agents/items_run_item.go
@@ -150,6 +150,14 @@ func TResponseInputItemFromToolCallItemType(input ToolCallItemType) TResponseInp
 		return TResponseInputItemFromResponseComputerToolCall(v)
 	case ResponseOutputItemLocalShellCall:
 		return TResponseInputItemFromResponseOutputItemLocalShellCall(v)
+	case ResponseFileSearchToolCall:
+		return openaitypes.ResponseInputItemUnionParamFromResponseFileSearchToolCall(
+			responses.ResponseFileSearchToolCall(v),
+		)
+	case ResponseFunctionWebSearch:
+		return openaitypes.ResponseInputItemUnionParamFromResponseFunctionWebSearch(
+			responses.ResponseFunctionWebSearch(v),
+		)
 	default:
 		// This would be an unrecoverable implementation bug, so a panic is appropriate.
 		panic(fmt.Errorf("unexpected ToolCallItemType type %T", v))

--- a/agents/items_run_item_test.go
+++ b/agents/items_run_item_test.go
@@ -1,0 +1,39 @@
+package agents
+
+import (
+	"testing"
+
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTResponseInputItemFromToolCallItemType_FileSearchCall(t *testing.T) {
+	input := ResponseFileSearchToolCall(responses.ResponseFileSearchToolCall{
+		ID:      "fs_1",
+		Queries: []string{"hello"},
+	})
+
+	require.NotPanics(t, func() {
+		out := TResponseInputItemFromToolCallItemType(input)
+		require.NotNil(t, out.OfFileSearchCall)
+		require.Equal(t, "fs_1", out.OfFileSearchCall.ID)
+	})
+}
+
+func TestTResponseInputItemFromToolCallItemType_WebSearchCall(t *testing.T) {
+	input := ResponseFunctionWebSearch(responses.ResponseFunctionWebSearch{
+		ID: "ws_1",
+		Action: responses.ResponseFunctionWebSearchActionUnion{
+			Type:  "search",
+			Query: "hello",
+		},
+	})
+
+	require.NotPanics(t, func() {
+		out := TResponseInputItemFromToolCallItemType(input)
+		require.NotNil(t, out.OfWebSearchCall)
+		require.Equal(t, "ws_1", out.OfWebSearchCall.ID)
+		require.NotNil(t, out.OfWebSearchCall.Action.OfSearch)
+		require.Equal(t, "hello", out.OfWebSearchCall.Action.OfSearch.Query)
+	})
+}


### PR DESCRIPTION
## Fix: persist session memory for web/file search tool calls

### Summary
When `Runner.saveResultToSession(...)` persists `result.NewItems`, it converts each `RunItem` to a `TResponseInputItem`. For `ToolCallItem`s, this goes through `TResponseInputItemFromToolCallItemType(...)`. The current implementation does not handle:
- `ResponseFunctionWebSearch` (`web_search_call`)
- `ResponseFileSearchToolCall` (`file_search_call`)

This causes a `panic` (`unexpected ToolCallItemType type %T`) whenever an agent uses `web_search_preview` (or file search) with a `Session` configured, preventing session messages from being written.

### Changes
- Added support for `ResponseFileSearchToolCall` and `ResponseFunctionWebSearch` in `agents/items_run_item.go` by converting them to `responses.*` and wrapping them with the corresponding `openaitypes.ResponseInputItemUnionParamFrom...` helpers.
- Added regression tests to ensure these tool call items no longer panic and are converted into the expected `TResponseInputItem` union fields.

### Files
- `agents/items_run_item.go`
- `agents/items_run_item_test.go`

### Testing
- `go test ./agents/...`

### Notes
This is intentionally a minimal change to unblock session persistence for `web_search_call` and `file_search_call` tool items without altering any other behavior.
